### PR TITLE
fix: temporary fix / fix reslice not working

### DIFF
--- a/Sources/Imaging/Core/ImageReslice/index.js
+++ b/Sources/Imaging/Core/ImageReslice/index.js
@@ -363,7 +363,8 @@ function vtkImageReslice(publicAPI, model) {
       borderMode === ImageBorderMode.CLAMP &&
       !(
         optimizedTransform != null ||
-        perspective ||
+        // FIXME: calculate mpr texture when !optimizeNearest
+        // perspective ||
         convertScalars != null ||
         rescaleScalars
       ) &&


### PR DESCRIPTION
* optimizeNearest 값이 버전이 올라가면서 바뀜 (perspective가 true로 판정됨)
* !optimizeNearest일때 mpr texture를 계산해주는 logic이 없음 (만들어야 하는 부분)
* 우선은 perspective 조건을 삭제 했을때 3D 뷰어 한정 정상동작 확인

