### PR TITLE
fix: Remove MPR position texture in vtkImageReslice

### DIFF
--- a/Sources/Imaging/Core/ImageReslice/index.js
+++ b/Sources/Imaging/Core/ImageReslice/index.js
@@ -314,7 +314,6 @@ function vtkImageReslice(publicAPI, model) {
     let outPtr = outScalars.getData();
     const outExt = output.getExtent();
     const newmat = indexMatrix;
-    model.mprtest = newmat;
     const outputStencil = null;
 
     //console.log("outext : " + outExt);
@@ -1104,7 +1103,6 @@ const DEFAULT_VALUES = {
   interpolator: vtkImageInterpolator.newInstance(),
   usePermuteExecute: false, // no supported yet
   inpoint: null,
-  mprtest : null,
   isMPRCustom: false,
 };
 
@@ -1136,7 +1134,6 @@ export function extend(publicAPI, model, initialValues = {}) {
     'slabNumberOfSlices',
     'slabSliceSpacingFraction',
     'inpoint',
-    'mprtest',
     'isMPRCustom',
   ]);
 

--- a/Sources/Imaging/Core/ImageReslice/index.js
+++ b/Sources/Imaging/Core/ImageReslice/index.js
@@ -318,8 +318,6 @@ function vtkImageReslice(publicAPI, model) {
     const outputStencil = null;
 
     //console.log("outext : " + outExt);
-    model.mprCoordTexture = new Uint16Array((outExt[1]+1)*(outExt[3]+1)*3);
-    model.mprCoordTexture.fill(50000);
     // multiple samples for thick slabs
     const nsamples = Math.max(model.slabNumberOfSlices, 1);
 
@@ -363,8 +361,7 @@ function vtkImageReslice(publicAPI, model) {
       borderMode === ImageBorderMode.CLAMP &&
       !(
         optimizedTransform != null ||
-        // FIXME: calculate mpr texture when !optimizeNearest
-        // perspective ||
+        perspective ||
         convertScalars != null ||
         rescaleScalars
       ) &&
@@ -442,7 +439,6 @@ function vtkImageReslice(publicAPI, model) {
     iter.initialize(output, outExt, model.stencil, null);
     const outPtr0 = iter.getScalars(output, 0);
     let outPtrIndex = 0;
-    //let MPRcoordIndex = 0;
     let count = 0;
     const outTmp = macro.newTypedArray(
       scalarType,
@@ -454,7 +450,6 @@ function vtkImageReslice(publicAPI, model) {
 
     for (; !iter.isAtEnd(); iter.nextSpan()) {
       const span = iter.spanEndId() - iter.getId();
-      //MPRcoordIndex = iter.getId() * scalarSize * 3;
       outPtrIndex = iter.getId() * scalarSize * outComponents;
 
       //console.log(outPtrIndex, iter.getId(), scalarSize, outComponents);
@@ -486,6 +481,11 @@ function vtkImageReslice(publicAPI, model) {
           inPoint1[1] = inPoint0[1] + idY * yAxis[1];
           inPoint1[2] = inPoint0[2] + idY * yAxis[2];
           inPoint1[3] = inPoint0[3] + idY * yAxis[3];
+        }
+        model.inpoint = inPoint1;
+
+        if (model.isMPRCustom) {
+          return;
         }
 
         // march through one row of the output image
@@ -686,12 +686,6 @@ function vtkImageReslice(publicAPI, model) {
               // perform nearest-neighbor interpolation via pixel copy
               let offset = inIdX * inIncX + inIdY * inIncY + inIdZ * inIncZ;
 
-              model.mprCoordTexture[outPtrIndex * 3] = inIdX;
-              //MPRcoordIndex++;
-              model.mprCoordTexture[outPtrIndex * 3 + 1] = inIdY;
-              //MPRcoordIndex++;
-              model.mprCoordTexture[outPtrIndex * 3 + 2] = inIdZ;
-              //MPRcoordIndex++;
               // when memcpy is used with a constant size, the compiler will
               // optimize away the function call and use the minimum number
               // of instructions necessary to perform the copy
@@ -1109,8 +1103,9 @@ const DEFAULT_VALUES = {
   // resliceTransform: null,
   interpolator: vtkImageInterpolator.newInstance(),
   usePermuteExecute: false, // no supported yet
-  mprCoordTexture : null,
+  inpoint: null,
   mprtest : null,
+  isMPRCustom: false,
 };
 
 // ----------------------------------------------------------------------------
@@ -1140,8 +1135,9 @@ export function extend(publicAPI, model, initialValues = {}) {
     'slabTrapezoidIntegration',
     'slabNumberOfSlices',
     'slabSliceSpacingFraction',
-    'mprCoordTexture',
+    'inpoint',
     'mprtest',
+    'isMPRCustom',
   ]);
 
   macro.setGetArray(publicAPI, model, ['outputOrigin', 'outputSpacing'], 3);


### PR DESCRIPTION
MPR position texture 계산 삭제
**기존에 임시로 해놨던 조치 해제**

imageReslice 코드를 보니 `inpoint`를 통해 texture 생성 없이도 mpr_start 값을 계산해낼 수 있어서
MPR position texture를 삭제함.

`isMPRCustom` 파라미터를 image reslice 객체에 추가해서 custom MPR logic을 사용하는 경우에 불필요한 계산을 하지 않도록 수정함.
