### PR TITLE
fix: Fix black bounding box problem

### DIFF
--- a/Sources/Rendering/OpenGL/glsl/vtkHHVolumeFS.glsl
+++ b/Sources/Rendering/OpenGL/glsl/vtkHHVolumeFS.glsl
@@ -1860,7 +1860,7 @@ vec2 computeRayDistances(vec3 rayDir, vec3 tdims)
 {
   vec2 dists = vec2(100.0*camFar, -1.0);
 
-  vec3 vSize = vSpacing*(tdims - 1.0);
+  vec3 vSize = vSpacing*(tdims);
 
   // all this is in View Coordinates
   getRayPointIntersectionBounds(vertexVCVSOutput, rayDir,


### PR DESCRIPTION
옛날 계산 방식으로 revert
왜 때문에 바꼈고 왜 때문에 까만 보더가 생기는지는 아직 모르지만
아마도 camera position과 관련이 있을거라 추정 중.
FIXME를 달아놨고 이후 추가로 코드를 파악할 필요가 있음.

\+ 수정
셰이더 코드 옮길때 발생한 버그임.
https://github.com/Kitware/vtk-js/commit/dcb2573a274197683ce001f4feb70969f247acde
이 PR로 완전히 fix.