### PR TITLE
feat: Set out of bounds pixels to black

### DIFF
--- a/Sources/Rendering/OpenGL/ImageMapper/index.js
+++ b/Sources/Rendering/OpenGL/ImageMapper/index.js
@@ -373,24 +373,28 @@ function vtkOpenGLImageMapper(publicAPI, model) {
 
                 'vec3 sampleStep = tRay.xyz * cprThickness / float(thickness);',
                 'vec3 start = img.xyz + -tRay.xyz * cprThickness * 0.5;',
-                // 이미지 밖의 점은 까만색으로 처리
-                `if (start.x < 0.0 || start.x > 1.0) {
-                  gl_FragData[0] = vec4(0.0, 0.0, 0.0, 1.0);
-                  return;
-                }`,
-                `if (start.y < 0.0 || start.y > 1.0) {
-                  gl_FragData[0] = vec4(0.0, 0.0, 0.0, 1.0);
-                  return;
-                }`,
-                `if (start.z < 0.0 || start.z > 1.0) {
-                  gl_FragData[0] = vec4(0.0, 0.0, 0.0, 1.0);
-                  return;
-                }`,
                 'float intensity = 0.0;',
+                'int count = 0;',
                 'for (int i = 0; i < thickness + 1; ++i) {',
-                '  intensity += texture(texture2, start + float(i) * sampleStep).r;',
+                '  vec3 step = start + float(i) * sampleStep;',
+                // 이미지 밖의 점은 까만색으로 처리
+                `  if (step.x < 0.0 || step.x > 1.0) {
+                     continue;
+                   }
+                   if (step.y < 0.0 || step.y > 1.0) {
+                     continue;
+                   }
+                   if (step.z < 0.0 || step.z > 1.0) {
+                     continue;
+                   }`,
+                '  count = count + 1;',
+                '  intensity += texture(texture2, step).r;',
                 '}',
-                'float avg = intensity / (float(thickness) + 1.0);',
+                `if (count == 0) {
+                  gl_FragData[0] = vec4(0.0, 0.0, 0.0, 1.0);
+                  return;
+                }`,
+                'float avg = intensity / (float(count) + 1.0);',
 
                 'vec3 tcolor = texture2D(colorTexture1, vec2(avg * cscale0 + cshift0, 0.5)).rgb;',
                 'float scalarOpacity = texture2D(pwfTexture1, vec2(avg * pwfscale0 + pwfshift0, 0.5)).r;',

--- a/Sources/Rendering/OpenGL/ImageMapper/index.js
+++ b/Sources/Rendering/OpenGL/ImageMapper/index.js
@@ -373,7 +373,19 @@ function vtkOpenGLImageMapper(publicAPI, model) {
 
                 'vec3 sampleStep = tRay.xyz * cprThickness / float(thickness);',
                 'vec3 start = img.xyz + -tRay.xyz * cprThickness * 0.5;',
-
+                // 이미지 밖의 점은 까만색으로 처리
+                `if (start.x < 0.0 || start.x > 1.0) {
+                  gl_FragData[0] = vec4(0.0, 0.0, 0.0, 1.0);
+                  return;
+                }`,
+                `if (start.y < 0.0 || start.y > 1.0) {
+                  gl_FragData[0] = vec4(0.0, 0.0, 0.0, 1.0);
+                  return;
+                }`,
+                `if (start.z < 0.0 || start.z > 1.0) {
+                  gl_FragData[0] = vec4(0.0, 0.0, 0.0, 1.0);
+                  return;
+                }`,
                 'float intensity = 0.0;',
                 'for (int i = 0; i < thickness + 1; ++i) {',
                 '  intensity += texture(texture2, start + float(i) * sampleStep).r;',


### PR DESCRIPTION
기존에 axial cpr 하는 높이만큼 이미지가 없으면 엣지의 픽셀 값을 가져다 써서 이미지가 아래와 같이 표시되는 단점?이 있었는데
<img width="1248" alt="스크린샷 2024-01-25 오전 8 54 21" src="https://github.com/HealthHub0301/vtk-js/assets/78520712/6a4b8ca9-28ca-4179-a767-99b9fe2ed0ca">

좌표가 경계 밖일 경우엔 까만색으로 처리하게 바꿨습니다.
<img width="1199" alt="스크린샷 2024-01-25 오전 8 53 27" src="https://github.com/HealthHub0301/vtk-js/assets/78520712/a48b42a9-9e2e-4bbe-b244-ab0dd9034c4d">